### PR TITLE
Add setMode() to trigger a measurement in forced mode

### DIFF
--- a/BME280.cpp
+++ b/BME280.cpp
@@ -143,6 +143,11 @@ BME280::BME280(uint8_t tosr, uint8_t hosr, uint8_t posr, uint8_t mode, uint8_t s
   config = (standbyTime << 5) | (filter << 2) | spiEnable;
 }
 
+void BME280::setMode(uint8_t mode){
+  controlMeasure = controlMeasure | mode;
+  WriteRegister(CTRL_MEAS_ADDR, controlMeasure);
+}
+
 float BME280::temp(bool celsius){
   int32_t data[8];
   int32_t t_fine;

--- a/BME280.h
+++ b/BME280.h
@@ -85,6 +85,8 @@ public:
   /* ==== Method used at start up to initialize the class. ==== */
   virtual bool begin()=0;
 
+  void setMode(uint8_t mode);
+
   /* ==== Read the temperature from the BME280 and return a float. ==== */
   float temp(bool celsius = true);
 

--- a/BME280.h
+++ b/BME280.h
@@ -80,7 +80,7 @@ protected:
 public:
   /* ==== Constructor used to create the class. All parameters have default values. ==== */
   BME280(uint8_t tosr = 0x1, uint8_t hosr = 0x1, uint8_t posr = 0x1, uint8_t mode = 0x3,
-    uint8_t st = 0x5, uint8_t filter = 0x0, bool spiEnable = false);  // Oversampling = 1, mode = normal, standby time = 125ms, filter = none.
+    uint8_t st = 0x5, uint8_t filter = 0x0, bool spiEnable = false);  // Oversampling = 1, mode = normal, standby time = 1000ms, filter = none.
 
   /* ==== Method used at start up to initialize the class. ==== */
   virtual bool begin()=0;

--- a/BME280I2C.h
+++ b/BME280I2C.h
@@ -56,7 +56,7 @@ public:
   /* ==== Constructor used to create the class. All parameters have default values. ==== */
   BME280I2C(uint8_t tosr = 0x1, uint8_t hosr = 0x1, uint8_t posr = 0x1, uint8_t mode = 0x3,
     uint8_t st = 0x5, uint8_t filter = 0x0, bool spiEnable = false,
-    uint8_t bme_280_addr = 0x76);  // Oversampling = 1, mode = normal, standby time = 125ms, filter = none.
+    uint8_t bme_280_addr = 0x76);  // Oversampling = 1, mode = normal, standby time = 1000ms, filter = none.
 
   /* ==== Method used at start up to initialize the class. Starts the I2C interface. ==== */
   virtual bool begin();

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Provides an Arduino library for reading and interpreting Bosch BME280 data.
 
  * [BME280(uint8_t tosr = 0x1, uint8_t hosr = 0x1, uint8_t posr = 0x1, uint8_t mode = 0x3, uint8_t st = 0x5, uint8_t filter = 0x0, bool spiEnable = false, uint8_t bme_280_addr = 0x76)](#methods)
  * [bool  begin()](#methods)
+ * [void  setMode(uint8_t mode)](#methods)
  * [float temp(bool celsius = true)](#methods)
  * [float pres(uint8_t unit = 0x0)](#methods)
  * [float hum()](#methods)
@@ -58,6 +59,8 @@ or
 `altitude = bme.alt()`
 `dewPoint = bme.dew()`
 
+Use `setMode(0x01)` to trigger a new measurement in forced mode. NOTE: It takes ~8ms to measure all values (temp, humidity & pressure) when using x1 oversampling (see datasheet 11.1). Thus a delay of >8ms should be used after triggering a measurement and before reading data to ensure that read values are the latest ones.
+
 ## Methods
 
 
@@ -97,6 +100,10 @@ or
 
   Method used at start up to initialize the class. Starts the I2C interface.
   Return: bool, true = success, false = failure (no device found)
+
+#### void setMode(uint8_t mode)
+
+  Method to set the sensor mode. Sleep = B00, Forced = B01 and B10, Normal = B11. Set to B01 to trigger a new measurement when using forced mode.
 
 #### float temp(bool celsius = true)
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Use `setMode(0x01)` to trigger a new measurement in forced mode. NOTE: It takes 
     * Pressure Oversampling Rate (posr): uint8_t, default = 0x1
       values: B000 = Skipped, B001 = x1, B010 = x2, B011 = x4, B100 = x8, B101/other = x16
 
-    * Mode: uint8_t, default = forced
-      values: Sleep = B00, Normal = B01 and B10, Forced = B11
+    * Mode: uint8_t, default = Normal
+      values: Sleep = B00, Forced = B01 and B10, Normal = B11
 
     * Standby Time (st): uint8_t, default = 1000ms
       values: B000 = 0.5ms, B001 = 62.5ms, B010 = 125ms, B011 = 250ms, B100 = 250ms, B101 = 1000ms, B110 = 10ms, B111 = 20ms


### PR DESCRIPTION
Sensors operation mode can now be changed without the initialization overhead of `begin()`. This reduces the time needed to trigger a measurement in the forced mode from ~8ms to 3ms thus saving energy on battery operated devices.