### PR TITLE
Make CHIP_ID available to public

### DIFF
--- a/src/BME280.cpp
+++ b/src/BME280.cpp
@@ -70,6 +70,7 @@ bool BME280::Initialize()
   {
       return false;
   }
+  chip_id = id[0];
 
   WriteRegister(CTRL_HUM_ADDR, controlHumidity);
   WriteRegister(CTRL_MEAS_ADDR, controlMeasure);
@@ -435,3 +436,10 @@ float BME280::dew
   return dewPoint;
 }
 
+/****************************************************************/
+uint8_t BME280::chipID
+(
+)
+{
+  return chip_id;
+}

--- a/src/BME280.h
+++ b/src/BME280.h
@@ -146,6 +146,10 @@ public:
   /// Method used to initialize the class.
   bool begin();
 
+  ////////////////////////////////////////////////////////////////
+  /// Method used to return CHIP_ID.
+  uint8_t chipID();
+  
 protected:
 
 /*****************************************************************/
@@ -249,6 +253,7 @@ private:
   uint8_t controlMeasure;                     // ctrl_meas register. (ctrl_meas[7:5] = temperature oversampling rate, ctrl_meas[4:2] = pressure oversampling rate, ctrl_meas[1:0] = mode.)
   uint8_t config;                             // config register. (config[7:5] = standby time, config[4:2] = filter, ctrl_meas[0] = spi enable.)
   uint8_t dig[32];
+  uint8_t chip_id;
 
   bool spiEnable;
 


### PR DESCRIPTION
I'm having a mix of BMP280 and BME280 PCBs and it's sometimes hard to guess what chip I'm using so I can setup MQTT topics for existing metrics only. This patch exports CHIP_ID to user space so I'm finally able to achieve my goal, for example:

`
if (bme.chipID() == BME_ID) {
  client.subscribe("/humidity/command");
}
` 