### PR TITLE
Fix infinite recursion in BME280Spi::Initialize

### DIFF
--- a/src/BME280Spi.cpp
+++ b/src/BME280Spi.cpp
@@ -57,7 +57,7 @@ bool BME280Spi::Initialize()
   pinMode(csPin, OUTPUT);
   SPI.begin();
 
-  return Initialize();
+  return BME280::Initialize();
 }
 
 


### PR DESCRIPTION
`Initialize()` in the Bme280Spi variant recurses indefinitely.