### PR TITLE
Correct the output unit of the pressures

### DIFF
--- a/examples/BME280_Modes/BME280_Modes.ino
+++ b/examples/BME280_Modes/BME280_Modes.ino
@@ -122,5 +122,5 @@ void printBME280Data
    client->print("% RH");
    client->print("\t\tPressure: ");
    client->print(pres);
-   client->print(" atm");
+   client->print(" Pa");
 }

--- a/examples/BME_280_BRZO_I2C_Test/BME_280_BRZO_I2C_Test.ino
+++ b/examples/BME_280_BRZO_I2C_Test/BME_280_BRZO_I2C_Test.ino
@@ -84,5 +84,5 @@ void printBME280Data
    client->print("% RH");
    client->print("\t\tPressure: ");
    client->print(pres);
-   client->print(" atm");
+   client->print(" Pa");
 }

--- a/examples/BME_280_I2C_Test/BME_280_I2C_Test.ino
+++ b/examples/BME_280_I2C_Test/BME_280_I2C_Test.ino
@@ -72,5 +72,5 @@ void printBME280Data
    client->print("% RH");
    client->print("\t\tPressure: ");
    client->print(pres);
-   client->print(" atm");
+   client->print(" Pa");
 }

--- a/examples/BME_280_Spi_Sw_Test/BME_280_Spi_Sw_Test.ino
+++ b/examples/BME_280_Spi_Sw_Test/BME_280_Spi_Sw_Test.ino
@@ -76,5 +76,5 @@ void printBME280Data
    client->print("% RH");
    client->print("\t\tPressure: ");
    client->print(pres);
-   client->print(" atm");
+   client->print(" Pa");
 }

--- a/examples/BME_280_Spi_Test/BME_280_Spi_Test.ino
+++ b/examples/BME_280_Spi_Test/BME_280_Spi_Test.ino
@@ -77,5 +77,5 @@ void printBME280Data
    client->print("% RH");
    client->print("\t\tPressure: ");
    client->print(pres);
-   client->print(" atm");
+   client->print(" Pa");
 }

--- a/examples/Environment_Calculations/Environment_Calculations.ino
+++ b/examples/Environment_Calculations/Environment_Calculations.ino
@@ -72,7 +72,7 @@ void printBME280Data
    client->print("% RH");
    client->print("\t\tPressure: ");
    client->print(pres);
-   client->print(" atm");
+   client->print(" Pa");
 
    bool metric = true;
 


### PR DESCRIPTION
Examples are set to get pressure in Pa, but output shows atm as the unit.