### PR TITLE
Introduce ChipModel enum and chipModel() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ or
 ## Settings
 
 #### BME280::Settings Struct
+```
     * Temperature Oversampling Rate (tempOSR): OSR Enum, default = OSR_X1
 
     * Humidity Oversampling Rate (humOSR): OSR Enum, default = OSR_X1
@@ -127,14 +128,14 @@ or
 
     * SPI Enable: SpiEnable Enum, default = false
       values: true = enable, false = disable
-
+```
 
 #### BME280I2C::Settings Struct
 
    * Includes all fields in BME280 settings.
 ```
    * BME 280 Address (bme280Addr): uint8_t, default = 0x76
-````
+```
 #### BME280Spi::Settings Struct
 
    * Includes all fields in BME280 settings.
@@ -177,14 +178,14 @@ or
 
   Method used at start up to initialize the class. Starts the I2C or SPI interface. Can be called again to re-initialize the mode settings.
  ```
- * return: bool, true = success, false = failure (no device found)
+   * return: bool, true = success, false = failure (no device found)
  ```
 
 #### void setSettings(const Settings& settings)
 
   Method to set the sensor settings.
-  
-  
+
+
 #### const Settings& getSettings() const
 
   Method to get the sensor settings.
@@ -192,26 +193,32 @@ or
 #### float temp(TempUnit unit)
 
   Read the temperature from the BME280 and return a float.
-  Return: float = temperature
+```
+    return: float = temperature
 
     * unit: tempUnit, default = TempUnit_Celsius
+```
 
 #### float pres(PresUnit unit)
 
   Read the pressure from the BME280 and return a float with the specified unit.
-  Return: float = pressure
+```
+    return: float = pressure
 
     * unit: uint8_t, default = PresUnit_Pa
+```
 
 #### float hum()
 
   Read the humidity from the BME280 and return a percentage as a float.
+```
     * return: float = percent relative humidity
-
+```
 #### void  read(float& pressure, float& temp, float& humidity, TempUnit tempUnit, PresUnit presUnit)
 
   Read the data from the BME280 with the specified units.
-  Return: None, however, pressure, temp and humidity are changed.
+```
+    return: None, however, pressure, temp and humidity are changed.
 
     * Pressure: float, reference
       values: reference to storage float for pressure
@@ -225,16 +232,12 @@ or
     * tempUnit: tempUnit, default = TempUnit_Celsius
 
     * presUnit: uint8_t, default = PresUnit_Pa
-
-#### uint8_t chipID()
-   Returns the chip identification number.
-   ```
-    * return: uint8_t 0x60 = BME ID, 0x58 = BMP ID
-   ```
+```
 
 #### ChipModel chipModel()
-   Return: [ChipModel](#chipmodel-enum) enum
-
+```
+    * return: [ChipModel](#chipmodel-enum) enum
+```
 
 ## Environment Calculations
 
@@ -242,7 +245,7 @@ or
 
   Calculate the altitude based on the pressure with the specified units.
   Return: float = altitude
-
+```
     * Pressure: float, unit = Pa
       values: any float
 
@@ -251,13 +254,14 @@ or
 
     * Sea Level Pressure: float, unit = Pa, default = 101325
       values:  any float
+```
 
 #### float SealevelAlitude(float alitude, float temp, float pres)
 
   Convert current pressure to sea-level pressure, returns
   Altitude (in meters), temperature in Celsius
-
-  Return: The equivalent pressure at sea level.
+```
+    return: The equivalent pressure at sea level.
 
     * alitude: float
       values: meters
@@ -266,11 +270,13 @@ or
       values: celsius
 
     * hum: float
+```
 
 #### float DewPoint(float temp, float hum, bool metric = true)
 
   Calculate the dew point based on the temperature and humidity with the specified units.
-  Return: float = dew point
+```
+    return: float = dew point
 
     * Temperature: float, unit = Celsius if metric is true, Fahrenheit if metric is false
       values: any float
@@ -280,7 +286,7 @@ or
 
     * Metric: bool, default = true
       values: true = return degrees Celsius, false = return degrees Fahrenheit
-
+```
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ or
    * Filter_8
    * Filter_16
 
+#### ChipModel Enum
+   * ChipModel_Unknown
+   * ChipModel_BME280
+   * ChipModel_BMP280
+
 ## Settings
 
 #### BME280::Settings Struct
@@ -226,6 +231,9 @@ or
    ```
     * return: uint8_t 0x60 = BME ID, 0x58 = BMP ID
    ```
+
+#### ChipModel chipModel()
+   Return: [ChipModel](#chipmodel-enum) enum
 
 
 ## Environment Calculations

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Provides an Arduino library for reading and interpreting Bosch BME280 data over 
       - [float pres(PresUnit unit)](#methods)
       - [float hum()](#methods)
       - [void  read(float& pressure, float& temp, float& humidity, TempUnit tempUnit, PresUnit presUnit)](#methods)
-      - [uint8_t chipID()](#methods)
+      - [ChipModel chipModel()](#methods)
 
 9. [Environment Calculations](#environment-calculations)
       - [float Alitude(float pressure, bool metric = true, float seaLevelPressure = 101325)](#environment-calculations)

--- a/src/BME280.cpp
+++ b/src/BME280.cpp
@@ -68,11 +68,12 @@ bool BME280::ReadChipID()
 
    ReadRegister(ID_ADDR, &id[0], 1);
 
-   switch(id[0]) {
-      case BME_ID:
+   switch(id[0])
+   {
+      case ChipModel_BME280:
          m_chip_model = ChipModel_BME280;
          break;
-      case BMP_ID:
+      case ChipModel_BMP280:
          m_chip_model = ChipModel_BMP280;
          break;
       default:
@@ -80,7 +81,6 @@ bool BME280::ReadChipID()
          return false;
    }
 
-   m_chip_id = id[0];
    return true;
 }
 
@@ -396,14 +396,6 @@ void BME280::read
    humidity = CalculateHumidity(rawHumidity, t_fine);
 }
 
-
-/****************************************************************/
-uint8_t BME280::chipID
-(
-)
-{
-   return m_chip_id;
-}
 
 /****************************************************************/
 BME280::ChipModel BME280::chipModel

--- a/src/BME280.cpp
+++ b/src/BME280.cpp
@@ -68,13 +68,19 @@ bool BME280::ReadChipID()
 
    ReadRegister(ID_ADDR, &id[0], 1);
 
-   if (id[0] != BME_ID && id[0] != BMP_ID)
-   {
+   switch(id[0]) {
+      case BME_ID:
+         m_chip_model = ChipModel_BME280;
+         break;
+      case BMP_ID:
+         m_chip_model = ChipModel_BMP280;
+         break;
+      default:
+         m_chip_model = ChipModel_UNKNOWN;
          return false;
    }
 
    m_chip_id = id[0];
-
    return true;
 }
 
@@ -397,4 +403,12 @@ uint8_t BME280::chipID
 )
 {
    return m_chip_id;
+}
+
+/****************************************************************/
+BME280::ChipModel BME280::chipModel
+(
+)
+{
+   return m_chip_model;
 }

--- a/src/BME280.h
+++ b/src/BME280.h
@@ -101,6 +101,12 @@ enum SpiEnable{
    SpiEnable_True = 1
 };
 
+enum ChipModel {
+    ChipModel_UNKNOWN = 0,
+    ChipModel_BME280 = 1,
+    ChipModel_BMP280 = 2
+};
+
 struct Settings {
    Settings(
       OSR _tosr       = OSR_X1,
@@ -186,6 +192,10 @@ struct Settings {
    /// Method used to return CHIP_ID.
    uint8_t chipID();
 
+   ////////////////////////////////////////////////////////////////
+   /// Method used to return ChipModel.
+   ChipModel chipModel();
+
 protected:
 
 /*****************************************************************/
@@ -242,6 +252,7 @@ private:
 
    uint8_t m_dig[32];
    uint8_t m_chip_id;
+   ChipModel m_chip_model;
 
 
    bool m_initialized;

--- a/src/BME280.h
+++ b/src/BME280.h
@@ -239,6 +239,7 @@ private:
    static const uint8_t DIG_LENGTH              = 32;
    static const uint8_t SENSOR_DATA_LENGTH      = 8;
 
+
 /*****************************************************************/
 /* VARIABLES                                                     */
 /*****************************************************************/
@@ -248,6 +249,7 @@ private:
    ChipModel m_chip_model;
 
    bool m_initialized;
+
 
 /*****************************************************************/
 /* ABSTRACT FUNCTIONS                                            */
@@ -265,7 +267,6 @@ private:
       uint8_t addr,
       uint8_t data[],
       uint8_t length)=0;
-
 
 
 /*****************************************************************/
@@ -300,6 +301,7 @@ private:
    bool ReadData(
       int32_t data[8]);
 
+
    /////////////////////////////////////////////////////////////////
    /// Calculate the temperature from the BME280 raw data and
    /// BME280 trim, return a float.
@@ -322,8 +324,6 @@ private:
       int32_t raw,
       int32_t t_fine,
       PresUnit unit = PresUnit_Pa);
-
-
 
 };
 

--- a/src/BME280.h
+++ b/src/BME280.h
@@ -103,8 +103,8 @@ enum SpiEnable{
 
 enum ChipModel {
     ChipModel_UNKNOWN = 0,
-    ChipModel_BME280 = 1,
-    ChipModel_BMP280 = 2
+    ChipModel_BMP280 = 0x58,
+    ChipModel_BME280 = 0x60
 };
 
 struct Settings {
@@ -189,10 +189,6 @@ struct Settings {
    const Settings& getSettings() const;
 
    ////////////////////////////////////////////////////////////////
-   /// Method used to return CHIP_ID.
-   uint8_t chipID();
-
-   ////////////////////////////////////////////////////////////////
    /// Method used to return ChipModel.
    ChipModel chipModel();
 
@@ -235,8 +231,6 @@ private:
    static const uint8_t HUM_DIG_ADDR1   = 0xA1;
    static const uint8_t HUM_DIG_ADDR2   = 0xE1;
    static const uint8_t ID_ADDR         = 0xD0;
-   static const uint8_t BME_ID          = 0x60;
-   static const uint8_t BMP_ID          = 0x58;
 
    static const uint8_t TEMP_DIG_LENGTH         = 6;
    static const uint8_t PRESS_DIG_LENGTH        = 18;
@@ -251,9 +245,7 @@ private:
    Settings m_settings;
 
    uint8_t m_dig[32];
-   uint8_t m_chip_id;
    ChipModel m_chip_model;
-
 
    bool m_initialized;
 
@@ -291,7 +283,7 @@ private:
    /// Write the settings to the chip.
    bool WriteSettings();
 
-   
+
    /////////////////////////////////////////////////////////////////
    /// Read the the chip id data from the BME280, return true if
    /// successful and the id matches a known value.


### PR DESCRIPTION
The currently exposed `chipID()` method requires comparing against the values 0x58 and 0x60 manually as the constants are marked private. Instead of changing them to public, instead introduce a `ChipModel` enum and `chipModel()` method.

When the `m_chip_id` is read, the `m_chip_model` is also set, and the `chipModel()` method returns a value that can be compared against the accessible enum.

If new chips do wind up supported, they may be slightly easier to add now in the `switch`.

The existing `chipID()` method is left in place in case anyone is using it.