### PR TITLE
Equivalent Sea Level Pressure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Provides an Arduino library for reading and interpreting Bosch BME280 data over 
       - [ChipModel chipModel()](#methods)
 
 9. [Environment Calculations](#environment-calculations)
-      - [float Alitude(float pressure, bool metric = true, float seaLevelPressure = 101325)](#environment-calculations)
-      - [float SealevelAlitude(float alitude, float temp, float pres)](#environment-calculations)
+      - [float Altitude(float pressure, bool metric = true, float seaLevelPressure = 101325)](#environment-calculations)
+      - [float EquivalentSeaLevelPressure(float altitude, float temp, float pres)](#environment-calculations)
       - [float DewPoint(float temp, float hum, bool metric = true)](#environment-calculations)
 10. [Contributing](#contributing)
 11. [History](#history)
@@ -241,7 +241,7 @@ or
 
 ## Environment Calculations
 
-#### float Alitude(float pressure, bool metric = true, float seaLevelPressure = 101325)
+#### float Altitude(float pressure, bool metric = true, float seaLevelPressure = 101325)
 
   Calculate the altitude based on the pressure with the specified units.
   Return: float = altitude
@@ -256,20 +256,21 @@ or
       values:  any float
 ```
 
-#### float SealevelAlitude(float alitude, float temp, float pres)
+#### float EquivalentSeaLevelPressure(float altitude, float temp, float pres)
 
-  Convert current pressure to sea-level pressure, returns
-  Altitude (in meters), temperature in Celsius
+  Convert current pressure to equivalent sea-level pressure.
+
 ```
     return: The equivalent pressure at sea level.
 
-    * alitude: float
+    * altitude: float
       values: meters
 
     * temp: float
       values: celsius
 
-    * hum: float
+    * pres: float
+      values: unit independent
 ```
 
 #### float DewPoint(float temp, float hum, bool metric = true)

--- a/examples/Environment_Calculations/Environment_Calculations.ino
+++ b/examples/Environment_Calculations/Environment_Calculations.ino
@@ -90,7 +90,7 @@ void printBME280Data
 
    float altitude = EnvironmentCalculations::Altitude(pres, metric);
    float dewPoint = EnvironmentCalculations::DewPoint(temp, hum, metric);
-   float seaLevel = EnvironmentCalculations::SealevelAlitude(altitude, temp, pres);
+   float seaLevel = EnvironmentCalculations::EquivalentSeaLevelPressure(altitude, temp, pres);
 
    client->print("\t\tAltitude: ");
    client->print(altitude);

--- a/src/EnvironmentCalculations.cpp
+++ b/src/EnvironmentCalculations.cpp
@@ -49,14 +49,14 @@ float EnvironmentCalculations::Altitude
 
 
 /****************************************************************/
-float EnvironmentCalculations::SealevelAlitude
+float EnvironmentCalculations::EquivalentSeaLevelPressure
 (
-  float A,
-  float T,
-  float P
+  float alitude,
+  float temp,
+  float pres
 )
 {
-   return(P / pow(1-((0.0065 *A) / (T + (0.0065 *A) + 273.15)),5.257));
+   return(pres / pow(1-((0.0065 *alitude) / (temp + (0.0065 *alitude) + 273.15)),5.257));
 }
 
 

--- a/src/EnvironmentCalculations.h
+++ b/src/EnvironmentCalculations.h
@@ -37,19 +37,21 @@ namespace EnvironmentCalculations
   /////////////////////////////////////////////////////////////////
   /// Calculate the altitude based on the pressure with the
   /// specified units.
+  /// @param seaLevelPressure given in Pa.
   float Altitude(
     float pressure,
     bool metric = true,
-    float seaLevelPressure = 101325); // Pressure given in Pa.
+    float seaLevelPressure = 101325);
 
   /////////////////////////////////////////////////////////////////
-  /// Convert current pressure to sea-level pressure, returns
-  /// Altitude (in meters), temperature in Celsius
-  /// return the equivalent pressure at sea level.
-  float SealevelAlitude(
-   float alitude,
-   float temp,
-   float pres);  // A: current altitude (meters).
+  /// Convert current pressure to equivalent sea-level pressure.
+  /// @param altitude in meters.
+  /// @param temp in Celsius.
+  /// @return the equivalent pressure at sea level.
+  float EquivalentSeaLevelPressure(
+    float altitude,
+    float temp,
+    float pres);
 
 
   /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Renaming sealevelAltitude to equivalentSeaLevelPressure. Fixing documentation. Updating code. Fixing altitude spelling. Thank you spell checker. Note - stop spelling things wrong.