### PR TITLE
Filtering

### DIFF
--- a/src/BME280.cpp
+++ b/src/BME280.cpp
@@ -53,6 +53,12 @@ bool BME280::Initialize()
    if(success)
    {
       success &= ReadTrim();
+
+      if(m_settings.filter != Filter_Off)
+      {
+        InitializeFilter();
+      }
+      
       WriteSettings();
    }
 
@@ -60,6 +66,24 @@ bool BME280::Initialize()
 
    return m_initialized;
 }
+
+
+/****************************************************************/
+bool BME280::InitializeFilter()
+{
+  // Force an unfiltered measurement to populate the filter buffer.
+  // This fixes a bug that causes the first read to always be 28.82 °C 81732.34 hPa.
+  Filter filter = m_settings.filter;
+  m_settings.filter = Filter_Off;
+
+  WriteSettings();
+
+  float dummy;
+  read(dummy, dummy, dummy);
+
+  m_settings.filter = filter;
+}
+
 
 /****************************************************************/
 bool BME280::ReadChipID()

--- a/src/BME280.h
+++ b/src/BME280.h
@@ -211,7 +211,7 @@ protected:
    virtual bool Initialize();
 
    ///////////////////////////////////////////////////////////////
-   /// Force a non-filtered measurement to populate the filter 
+   /// Force a unfiltered measurement to populate the filter 
    /// buffer.
    bool InitializeFilter();
 

--- a/src/BME280.h
+++ b/src/BME280.h
@@ -205,9 +205,15 @@ protected:
 /* CONSTRUCTOR INIT FUNCTIONS                                    */
 /*****************************************************************/
 
-   //////////////////////////////////////////////////////////////////
+   ///////////////////////////////////////////////////////////////
    /// Write configuration to BME280, return true if successful.
+   /// Must be called from any child classes.
    virtual bool Initialize();
+
+   ///////////////////////////////////////////////////////////////
+   /// Force a non-filtered measurement to populate the filter 
+   /// buffer.
+   bool InitializeFilter();
 
 
 /*****************************************************************/

--- a/src/BME280SpiSw.h
+++ b/src/BME280SpiSw.h
@@ -81,7 +81,8 @@ class BME280SpiSw: public BME280{
 protected:
 
    ////////////////////////////////////////////////////////////////
-   /// Method used at start up to initialize the class. Starts the I2C interface.
+   /// Method used at start up to initialize the class. Starts the
+   /// software SPI interface.
    virtual bool Initialize();
 
 private:


### PR DESCRIPTION
### Related issue # and issue behavior

This resolves #62 and #59, where the initial read of a sensor was bogus if filtering was enabled.

### Description of changes/fixes

Added InitializeFilter, which calls read to initialize the filter buffer.

### @mention a person to review

@coelner  has reviewed the changes.

### Steps to test

Start the sensor and check the initial value compared to the subsequent values.

### Any outstanding TODOs or known issues

None known.