### PR TITLE
Patches

### DIFF
--- a/examples/BME280_Modes/BME280_Modes.ino
+++ b/examples/BME280_Modes/BME280_Modes.ino
@@ -69,7 +69,6 @@ BME280I2C::Settings settings(
    BME280::Mode_Forced,
    BME280::StandbyTime_1000ms,
    BME280::Filter_Off,
-   BME280::SpiEnable_False,
    BME280I2C::I2CAddr_0x76 // I2C address. I2C specific.
 );
 
@@ -111,7 +110,7 @@ void setup()
 void loop()
 {
    printBME280Data(&Serial);
-   delay(500);
+   delay(1000);
 }
 
 //////////////////////////////////////////////////////////////////
@@ -120,13 +119,19 @@ void printBME280Data
    Stream* client
 )
 {
-   float temp(NAN), hum(NAN), pres(NAN);
+  // Force measurement and wait till it is completed (see Data sheet)
+  bme.force();
+  while(bme.busy()) delay(1);
+
+  // Read last measurement
+  float temp(NAN), hum(NAN), pres(NAN);
 
    BME280::TempUnit tempUnit(BME280::TempUnit_Celsius);
    BME280::PresUnit presUnit(BME280::PresUnit_Pa);
 
    bme.read(pres, temp, hum, tempUnit, presUnit);
 
+   // Print result
    client->print("Temp: ");
    client->print(temp);
    client->print("°"+ String(tempUnit == BME280::TempUnit_Celsius ? 'C' :'F'));
@@ -136,6 +141,4 @@ void printBME280Data
    client->print("\t\tPressure: ");
    client->print(pres);
    client->println("Pa");
-
-   delay(1000);
 }

--- a/examples/BME_280_BRZO_I2C_Test/BME_280_BRZO_I2C_Test.ino
+++ b/examples/BME_280_BRZO_I2C_Test/BME_280_BRZO_I2C_Test.ino
@@ -72,7 +72,7 @@ void setup()
 void loop()
 {
    printBME280Data(&Serial);
-   delay(500);
+   delay(1000);
 }
 
 //////////////////////////////////////////////////////////////////
@@ -81,6 +81,9 @@ void printBME280Data
    Stream* client
 )
 {
+   bme.force();
+   while(bme.busy()) delay(1);
+
    float temp(NAN), hum(NAN), pres(NAN);
 
    BME280::TempUnit tempUnit(BME280::TempUnit_Celsius);
@@ -97,6 +100,4 @@ void printBME280Data
    client->print("\t\tPressure: ");
    client->print(pres);
    client->println("Pa");
-
-   delay(1000);
 }

--- a/examples/BME_280_I2C_Test/BME_280_I2C_Test.ino
+++ b/examples/BME_280_I2C_Test/BME_280_I2C_Test.ino
@@ -60,7 +60,7 @@ void setup()
 void loop()
 {
    printBME280Data(&Serial);
-   delay(500);
+   delay(1000);
 }
 
 //////////////////////////////////////////////////////////////////
@@ -69,7 +69,10 @@ void printBME280Data
    Stream* client
 )
 {
-   float temp(NAN), hum(NAN), pres(NAN);
+  bme.force();
+  delay(10);
+
+  float temp(NAN), hum(NAN), pres(NAN);
 
    BME280::TempUnit tempUnit(BME280::TempUnit_Celsius);
    BME280::PresUnit presUnit(BME280::PresUnit_Pa);
@@ -85,6 +88,4 @@ void printBME280Data
    client->print("\t\tPressure: ");
    client->print(pres);
    client->println("Pa");
-
-   delay(1000);
 }

--- a/examples/BME_280_Spi_Sw_Test/BME_280_Spi_Sw_Test.ino
+++ b/examples/BME_280_Spi_Sw_Test/BME_280_Spi_Sw_Test.ino
@@ -73,6 +73,9 @@ void printBME280Data
    Stream* client
 )
 {
+   bme.force();
+   while(bme.busy()) delay(1);
+
    float temp(NAN), hum(NAN), pres(NAN);
 
    BME280::TempUnit tempUnit(BME280::TempUnit_Celsius);
@@ -89,6 +92,4 @@ void printBME280Data
    client->print("\t\tPressure: ");
    client->print(pres);
    client->println("Pa");
-
-   delay(1000);
 }

--- a/examples/BME_280_Spi_Test/BME_280_Spi_Test.ino
+++ b/examples/BME_280_Spi_Test/BME_280_Spi_Test.ino
@@ -65,7 +65,7 @@ void setup()
 void loop()
 {
    printBME280Data(&Serial);
-   delay(500);
+   delay(1000);
 }
 
 //////////////////////////////////////////////////////////////////
@@ -74,6 +74,9 @@ void printBME280Data
    Stream* client
 )
 {
+   bme.force();
+   while(bme.busy()) delay(1);
+
    float temp(NAN), hum(NAN), pres(NAN);
 
    BME280::TempUnit tempUnit(BME280::TempUnit_Celsius);
@@ -90,6 +93,4 @@ void printBME280Data
    client->print("\t\tPressure: ");
    client->print(pres);
    client->println("Pa");
-
-   delay(1000);
 }

--- a/examples/Environment_Calculations/Environment_Calculations.ino
+++ b/examples/Environment_Calculations/Environment_Calculations.ino
@@ -38,7 +38,6 @@ BME280I2C::Settings settings(
    BME280::Mode_Forced,
    BME280::StandbyTime_1000ms,
    BME280::Filter_16,
-   BME280::SpiEnable_False,
    BME280I2C::I2CAddr_0x76
 );
 
@@ -81,7 +80,7 @@ void setup()
 void loop()
 {
    printBME280Data(&Serial);
-   delay(500);
+   delay(1000);
 }
 
 //////////////////////////////////////////////////////////////////
@@ -90,6 +89,9 @@ void printBME280Data
    Stream* client
 )
 {
+   bme.force();
+   while(bme.busy()) delay(1);
+
    float temp(NAN), hum(NAN), pres(NAN);
 
    BME280::TempUnit tempUnit(BME280::TempUnit_Celsius);
@@ -140,6 +142,4 @@ void printBME280Data
 
    client->print("\t\tAbsolute Humidity: ");
    client->println(absHum);
-
-   delay(1000);
 }

--- a/src/BME280.cpp
+++ b/src/BME280.cpp
@@ -242,6 +242,35 @@ bool BME280::ReadData
 
 
 /****************************************************************/
+bool BME280::ReadStatus
+(
+  bool& measuring,
+  bool& im_update
+ )
+{
+  uint8_t status = 0;
+  bool success = ReadRegister(STATUS_ADDR, &status, 1);
+
+  if(success) {
+    measuring = status & (1 << 3);
+    im_update = status & 1;
+  }
+
+  return success;
+}
+
+
+/****************************************************************/
+bool BME280::ReadCtrlMeas
+(
+ uint8_t& data
+)
+{
+  return ReadRegister(CTRL_MEAS_ADDR, &data, 1);
+}
+
+
+/****************************************************************/
 float BME280::CalculateTemperature
 (
    int32_t raw,
@@ -405,6 +434,30 @@ bool BME280::force()
 
 
 /****************************************************************/
+bool BME280::busy()
+{
+  bool measuring, dummy;
+
+  if(!ReadStatus(measuring, dummy)) { return false; }
+
+  return measuring;
+}
+
+
+/****************************************************************/
+BME280::Mode BME280::mode()
+{
+  uint8_t ctrlMeas;
+
+  if(!ReadCtrlMeas(ctrlMeas)) {
+    return static_cast<Mode>(0);
+  }
+
+  return static_cast<Mode>(ctrlMeas & 3);
+}
+
+
+/****************************************************************/
 void BME280::read
 (
    float& pressure,
@@ -430,9 +483,7 @@ void BME280::read
 
 
 /****************************************************************/
-BME280::ChipModel BME280::chipModel
-(
-)
+BME280::ChipModel BME280::chipModel()
 {
    return m_chip_model;
 }

--- a/src/BME280.cpp
+++ b/src/BME280.cpp
@@ -82,6 +82,8 @@ bool BME280::InitializeFilter()
   read(dummy, dummy, dummy);
 
   m_settings.filter = filter;
+
+  return true;
 }
 
 

--- a/src/BME280.h
+++ b/src/BME280.h
@@ -190,6 +190,9 @@ public:
       TempUnit  tempUnit    = TempUnit_Celsius,
       PresUnit  presUnit    = PresUnit_hPa);
 
+   /////////////////////////////////////////////////////////////////
+   /// Force measurement if in forced mode, returns true on success.
+   bool force();
 
 /*****************************************************************/
 /* ACCESSOR FUNCTIONS                                            */
@@ -264,6 +267,8 @@ private:
 
    bool m_initialized;
 
+   uint8_t mCtrlHum, mCtrlMeas, mConfig;
+
 
 /*****************************************************************/
 /* ABSTRACT FUNCTIONS                                            */
@@ -289,10 +294,7 @@ private:
 
    /////////////////////////////////////////////////////////////////
    /// Calculates registers based on settings.
-   void CalculateRegisters(
-      uint8_t& ctrlHum,
-      uint8_t& ctrlMeas,
-      uint8_t& config);
+   void CalculateRegisters();
 
    /////////////////////////////////////////////////////////////////
    /// Write the settings to the chip.
@@ -308,6 +310,11 @@ private:
    /// Read the the trim data from the BME280, return true if
    /// successful.
    bool ReadTrim();
+
+   /////////////////////////////////////////////////////////////////
+   /// Force the BME280 to take a measurement, return true if
+   /// successful.
+   bool ForceMeasurement();
 
    /////////////////////////////////////////////////////////////////
    /// Read the raw data from the BME280 into an array and return

--- a/src/BME280.h
+++ b/src/BME280.h
@@ -200,6 +200,14 @@ public:
    /// Force measurement if in forced mode, returns true on success.
    bool force();
 
+   /////////////////////////////////////////////////////////////////
+   /// True if device is currently measuring.
+   bool busy();
+
+   /////////////////////////////////////////////////////////////////
+   /// Read the current measurement mode from the BME280.
+   Mode mode();
+
 /*****************************************************************/
 /* ACCESSOR FUNCTIONS                                            */
 /*****************************************************************/
@@ -244,6 +252,7 @@ private:
 /*****************************************************************/
 
    static const uint8_t CTRL_HUM_ADDR   = 0xF2;
+   static const uint8_t STATUS_ADDR     = 0xF3;
    static const uint8_t CTRL_MEAS_ADDR  = 0xF4;
    static const uint8_t CONFIG_ADDR     = 0xF5;
    static const uint8_t PRESS_ADDR      = 0xF7;
@@ -327,6 +336,19 @@ private:
    /// true if successful.
    bool ReadData(
       int32_t data[8]);
+
+
+   /////////////////////////////////////////////////////////////////
+   /// Read status register from the BME280, return
+   /// true if successful.
+   bool ReadStatus(
+     bool& measuring,
+     bool& im_update);
+
+   /////////////////////////////////////////////////////////////////
+   /// Read measurement control register from the BME280, return
+   /// true if successful.
+   bool ReadCtrlMeas(uint8_t& data);
 
 
    /////////////////////////////////////////////////////////////////

--- a/src/BME280.h
+++ b/src/BME280.h
@@ -109,6 +109,12 @@ public:
       SpiEnable_True = 1
    };
 
+   enum I2CAddr
+   {
+     I2CAddr_0x76 = 0x76,
+     I2CAddr_0x77 = 0x77
+   };
+
    enum ChipModel
    {
       ChipModel_UNKNOWN = 0,

--- a/src/BME280I2C.cpp
+++ b/src/BME280I2C.cpp
@@ -68,10 +68,11 @@ bool BME280I2C::WriteRegister
   uint8_t data
 )
 {
-  Wire.beginTransmission(m_settings.bme280Addr);
-  Wire.write(addr);
-  Wire.write(data);
-  Wire.endTransmission();
+  TwoWire* wire = m_settings.bme280Port;
+  wire->beginTransmission(m_settings.bme280Addr);
+  wire->write(addr);
+  wire->write(data);
+  wire->endTransmission();
 
   return true; // TODO: Check return values from wire calls.
 }
@@ -87,15 +88,16 @@ bool BME280I2C::ReadRegister
 {
   uint8_t ord(0);
 
-  Wire.beginTransmission(m_settings.bme280Addr);
-  Wire.write(addr);
-  Wire.endTransmission();
+  TwoWire* wire = m_settings.bme280Port;
+  wire->beginTransmission(m_settings.bme280Addr);
+  wire->write(addr);
+  wire->endTransmission();
 
-  Wire.requestFrom(static_cast<uint8_t>(m_settings.bme280Addr), length);
+  wire->requestFrom(static_cast<uint8_t>(m_settings.bme280Addr), length);
 
-  while(Wire.available())
+  while(wire->available())
   {
-    data[ord++] = Wire.read();
+    data[ord++] = wire->read();
   }
 
   return ord == length;

--- a/src/BME280I2C.h
+++ b/src/BME280I2C.h
@@ -32,19 +32,14 @@ Based on the data sheet provided by Bosch for the Bme280 environmental sensor.
 
 #include "BME280.h"
 
+#include <Wire.h>
+
 //////////////////////////////////////////////////////////////////
 /// BME280I2C - I2C Implementation of BME280.
 class BME280I2C: public BME280
 {
 
 public:
-
-   enum I2CAddr
-   {
-      I2CAddr_0x76 = 0x76,
-      I2CAddr_0x77 = 0x77
-   };
-
 
    struct Settings : public BME280::Settings
    {
@@ -55,12 +50,13 @@ public:
          Mode _mode      = Mode_Forced,
          StandbyTime _st = StandbyTime_1000ms,
          Filter _filter  = Filter_16,
-         SpiEnable _se   = SpiEnable_False,
-         I2CAddr _addr   = I2CAddr_0x76
-        ): BME280::Settings(_tosr, _hosr, _posr, _mode, _st, _filter, _se),
-           bme280Addr(_addr) {}
+         I2CAddr _addr   = I2CAddr_0x76,
+         TwoWire* _port  = &Wire
+       ) : BME280::Settings(_tosr, _hosr, _posr, _mode, _st, _filter, SpiEnable_False),
+           bme280Addr(_addr), bme280Port(_port) {}
 
       I2CAddr bme280Addr;
+      TwoWire* bme280Port;
    };
 
    ///////////////////////////////////////////////////////////////
@@ -80,9 +76,6 @@ public:
 
    /////////////////////////////////////////////////////////////////
    const Settings& getSettings() const;
-
-
-protected:
 
 private:
 

--- a/src/BME280I2C_BRZO.h
+++ b/src/BME280I2C_BRZO.h
@@ -37,26 +37,27 @@ Based on the data sheet provided by Bosch for the Bme280 environmental sensor.
 
 //////////////////////////////////////////////////////////////////
 /// BME280I2C_BRZO - I2C Implementation of BME280.
-class BME280I2C_BRZO : public BME280I2C
+class BME280I2C_BRZO : public BME280
 {
 
 public:
 
-   struct Settings : public BME280I2C::Settings
+   struct Settings : public BME280::Settings
    {
       Settings(
-      OSR _tosr       = OSR_X1,
-      OSR _hosr       = OSR_X1,
-      OSR _posr       = OSR_X1,
-      Mode _mode      = Mode_Forced,
-      StandbyTime _st = StandbyTime_1000ms,
-      Filter _filter  = Filter_Off,
-      SpiEnable _se   = SpiEnable_False,
-      uint16_t _cr    = 400
-     ): BME280I2C::Settings(_tosr, _hosr, _posr, _mode, _st, _filter, _se),
-        i2cClockRate(_cr) {}
+        OSR _tosr       = OSR_X1,
+        OSR _hosr       = OSR_X1,
+        OSR _posr       = OSR_X1,
+        Mode _mode      = Mode_Forced,
+        StandbyTime _st = StandbyTime_1000ms,
+        Filter _filter  = Filter_Off,
+        I2CAddr _addr   = I2CAddr_0x76,
+        uint16_t _cr    = 400
+      ) : BME280::Settings(_tosr, _hosr, _posr, _mode, _st, _filter, SpiEnable_False),
+          bme280Addr(_addr), i2cClockRate(_cr) {}
 
-      uint16_t i2cClockRate;
+     I2CAddr bme280Addr;
+     uint16_t i2cClockRate;
    };
 
    ///////////////////////////////////////////////////////////////

--- a/src/BME280Spi.h
+++ b/src/BME280Spi.h
@@ -46,7 +46,7 @@ public:
          OSR _posr       = OSR_X1,
          Mode _mode      = Mode_Forced,
          StandbyTime _st = StandbyTime_1000ms,
-         Filter _filter  = Filter_Off,
+         Filter _filter  = Filter_Off
       ) : BME280::Settings(_tosr, _hosr, _posr, _mode, _st, _filter, SpiEnable_True),
           spiCsPin(_cspin) {}
 

--- a/src/BME280Spi.h
+++ b/src/BME280Spi.h
@@ -47,9 +47,8 @@ public:
          Mode _mode      = Mode_Forced,
          StandbyTime _st = StandbyTime_1000ms,
          Filter _filter  = Filter_Off,
-         SpiEnable _se   = SpiEnable_False
-        ): BME280::Settings(_tosr, _hosr, _posr, _mode, _st, _filter, _se),
-           spiCsPin(_cspin) {}
+      ) : BME280::Settings(_tosr, _hosr, _posr, _mode, _st, _filter, SpiEnable_True),
+          spiCsPin(_cspin) {}
 
       uint8_t spiCsPin;
    };


### PR DESCRIPTION
### Issue
The current implementation does not allow you to trigger the sensor correctly and with as little overhead as possible.

A measurement always results in unnecessary computation followed by the actual forcing and then by a read-out of the old value, as the sensor needs at least 5.5ms to acquire even a single measurement.

### Description of changes/fixes
These patches introduce the ```force()``` function to trigger a sensor measurement. The result can then be read out in the usual way at any later point in time (till it is triggered again). To know if the device is busy measuring or what mode it is in, it also introduces access to the state and mode register through the ```busy()``` and ```mode()``` function call.

It also includes a patch to support the use on none-default Wire interfaces and some minor cleanups.

All the examples were updated as well.

If necessary, I can also split the commit in separate requests.

### Steps to test
- Configure sensor in forced mode.
- Read measurements continuously and see that values do not change 
- Force a measurement
- Wait till the sensor is no longer ```busy()``` or its ```mode()``` no longer being forced.
- Retrieve new measurement.

**@kvoit significantly contributed to this work.**