### PR TITLE
Add missing return statements.

### DIFF
--- a/src/BME280.cpp
+++ b/src/BME280.cpp
@@ -82,6 +82,8 @@ bool BME280::InitializeFilter()
   read(dummy, dummy, dummy);
 
   m_settings.filter = filter;
+
+  return true;
 }
 
 
@@ -119,6 +121,8 @@ bool BME280::WriteSettings()
    WriteRegister(CTRL_HUM_ADDR, ctrlHum);
    WriteRegister(CTRL_MEAS_ADDR, ctrlMeas);
    WriteRegister(CONFIG_ADDR, config);
+
+   return true;
 }
 
 


### PR DESCRIPTION
### Related issue # and issue behavior
This fixes the compile warnings I get when using this library in my project.
The warnings are about two functions declared in the header file as returning a bool, but the actual implementation does not actually return a bool, returning a void instead.

### Description of changes/fixes
This patch adds the return statements (true) to the two functions that are missing them.