### PR TITLE
Return individual trimming parameters.

### DIFF
--- a/examples/UniqueId/UniqueBMEId.ino
+++ b/examples/UniqueId/UniqueBMEId.ino
@@ -1,0 +1,75 @@
+/*
+UniqueBMEId.ino
+
+This code shows how to read the unique BME Id from the BME280 environmental sensor.
+
+GNU General Public License
+
+Written: Dec 27 2019.
+
+Connecting the BME280 Sensor:
+Sensor              ->  Board
+-----------------------------
+Vin (Voltage In)    ->  3.3V
+Gnd (Ground)        ->  Gnd
+SDA (Serial Data)   ->  A4 on Uno/Pro-Mini, 20 on Mega2560/Due, 2 Leonardo/Pro-Micro, D2 on ESP8266
+SCK (Serial Clock)  ->  A5 on Uno/Pro-Mini, 21 on Mega2560/Due, 3 Leonardo/Pro-Micro, D1 on ESP8266
+
+ */
+
+#include <BME280I2C.h>
+#include <Wire.h>
+
+#define SERIAL_BAUD 115200
+
+BME280I2C::Settings settings(
+   BME280::OSR_X1,
+   BME280::OSR_X1,
+   BME280::OSR_X1,
+   BME280::Mode_Forced,
+   BME280::StandbyTime_1000ms,
+   BME280::Filter_16,
+   BME280::SpiEnable_False,
+   BME280I2C::I2CAddr_0x76
+);
+
+BME280I2C bme(settings);
+
+//////////////////////////////////////////////////////////////////
+void setup()
+{
+  Serial.begin(SERIAL_BAUD);
+
+  while(!Serial) {} // Wait
+
+  Wire.begin();
+
+  while(!bme.begin())
+  {
+    Serial.println("Could not find BME280 sensor!");
+    delay(1000);
+  }
+
+  switch(bme.chipModel())
+  {
+     case BME280::ChipModel_BME280:
+       Serial.println("Found BME280 sensor! Success.");
+       break;
+     case BME280::ChipModel_BMP280:
+       Serial.println("Found BMP280 sensor! No Humidity available.");
+       break;
+     default:
+       Serial.println("Found UNKNOWN sensor! Error!");
+  }
+
+  uint32_t uniqueID = bme.UniqueId();
+  Serial.printf("Unique ID: 0x%08X\n", uniqueID);
+
+}
+
+//////////////////////////////////////////////////////////////////
+void loop()
+{
+   delay(500);
+}
+

--- a/src/BME280.cpp
+++ b/src/BME280.cpp
@@ -58,7 +58,7 @@ bool BME280::Initialize()
       {
         InitializeFilter();
       }
-      
+
       WriteSettings();
    }
 
@@ -82,6 +82,8 @@ bool BME280::InitializeFilter()
   read(dummy, dummy, dummy);
 
   m_settings.filter = filter;
+
+  return true;
 }
 
 
@@ -119,6 +121,8 @@ bool BME280::WriteSettings()
    WriteRegister(CTRL_HUM_ADDR, ctrlHum);
    WriteRegister(CTRL_MEAS_ADDR, ctrlMeas);
    WriteRegister(CONFIG_ADDR, config);
+
+   return true;
 }
 
 

--- a/src/BME280.cpp
+++ b/src/BME280.cpp
@@ -434,14 +434,15 @@ BME280::ChipModel BME280::chipModel
    return m_chip_model;
 }
 
-
 /****************************************************************/
-uint8_t * BME280::compensationParameters
+uint32_t BME280::UniqueId
 (
-   uint8_t parameters[]
 )
 {
-   memcpy(parameters, m_dig, sizeof(m_dig));
-   return &parameters[0];
+   uint8_t buffer[4];
+   bool success;
+   success = ReadRegister(UNIQUE_ID_ADDR, buffer, 4);
+   return ((((uint32_t)buffer[3] + ((uint32_t)buffer[2] << 8)) & 0x7fff) << 16) + (((uint32_t)buffer[1]) << 8)+ (uint32_t)buffer[0];
 }
+
 

--- a/src/BME280.cpp
+++ b/src/BME280.cpp
@@ -433,3 +433,15 @@ BME280::ChipModel BME280::chipModel
 {
    return m_chip_model;
 }
+
+
+/****************************************************************/
+uint8_t * BME280::compensationParameters
+(
+   uint8_t parameters[]
+)
+{
+   memcpy(parameters, m_dig, sizeof(m_dig));
+   return &parameters[0];
+}
+

--- a/src/BME280.h
+++ b/src/BME280.h
@@ -199,6 +199,11 @@ public:
    /// Method used to return ChipModel.
    ChipModel chipModel();
 
+   ////////////////////////////////////////////////////////////////
+   /// Method to return compensation parameters.
+   uint8_t* compensationParameters(
+      uint8_t   parameters[32]);
+
 protected:
 
 /*****************************************************************/

--- a/src/BME280.h
+++ b/src/BME280.h
@@ -200,9 +200,8 @@ public:
    ChipModel chipModel();
 
    ////////////////////////////////////////////////////////////////
-   /// Method to return compensation parameters.
-   uint8_t* compensationParameters(
-      uint8_t   parameters[32]);
+   /// Unique Id of BME chip.
+   uint32_t UniqueId();
 
 protected:
 
@@ -250,6 +249,7 @@ private:
    static const uint8_t HUM_DIG_ADDR1   = 0xA1;
    static const uint8_t HUM_DIG_ADDR2   = 0xE1;
    static const uint8_t ID_ADDR         = 0xD0;
+   static const uint8_t UNIQUE_ID_ADDR  = 0x83;
 
    static const uint8_t TEMP_DIG_LENGTH         = 6;
    static const uint8_t PRESS_DIG_LENGTH        = 18;


### PR DESCRIPTION
### Related issue # and issue behavior
Issue #98: I would like to fingerprint each BME280 using the hash of the individual trimming parameters. I need a function that returns a copy of [uint8_t m_dig[32]](https://github.com/finitespace/BME280/blob/e1553a92191a2fb9f199789ba61b27e703233c13/src/BME280.h#L262).

### Description of changes/fixes
The receiving array has to be supplied by reference. The function returns the reference to this array too (so not void, see below an example).

### @mention a person to review
@finitespace, please comment. 

Alternative was to return a struct. The advantage would be the parameters (dig_T1 - dig_T3, dig_P1 - dig_P9 and dig_H1 - dig_H6) could be added. But I don't need them now, so I prefer keeping it simple.

### Steps to test
```c
uint8_t parameters[32];
CRC32 crc;
uint32_t checksum = CRC32::calculate(bme.compensationParameters(parameters), 32);

Serial.printf("SensorID: 0x%08X\nHash(CRC32) of ", checksum);  
for (int i=0; i<32; i++) Serial.printf("%02X ", parameters[i]);  
Serial.print("\n");
```
### Any outstanding TODOs or known issues
Adding an example (WIP)