### PR TITLE
H4/H5 are 12 bits signed integers

### DIFF
--- a/src/BME280.cpp
+++ b/src/BME280.cpp
@@ -274,8 +274,8 @@ float BME280::CalculateHumidity
    uint8_t   dig_H1 =   m_dig[24];
    int16_t dig_H2 = (m_dig[26] << 8) | m_dig[25];
    uint8_t   dig_H3 =   m_dig[27];
-   int16_t dig_H4 = (m_dig[28] << 4) | (0x0F & m_dig[29]);
-   int16_t dig_H5 = (m_dig[30] << 4) | ((m_dig[29] >> 4) & 0x0F);
+   int16_t dig_H4 = ((int8_t)m_dig[28] * 16) | (0x0F & m_dig[29]);
+   int16_t dig_H5 = ((int8_t)m_dig[30] * 16) | ((m_dig[29] >> 4) & 0x0F);
    int8_t   dig_H6 =   m_dig[31];
 
    var1 = (t_fine - ((int32_t)76800));


### PR DESCRIPTION
### Related issue # and issue behavior
12 bits signed integer are not handles properly, see #102 

### Description of changes/fixes
Propagate sign to 16 bit signed integer

### @mention a person to review

### Steps to test
Compare the following snippets of code:
```C++
	uint8_t byte = 0xf0;           // This is a negative value in an unsigned
	int16_t word = (byte << 4);    // Wrong way of propagating to 16bits signed

	Serial.print("Byte: ");
	Serial.println(byte, HEX);
	Serial.print("Word: ");
	Serial.println(word, HEX);

	word = ((int8_t)byte * 16);    // Better way of propagating to 16bits signed
	Serial.print("Word: ");
	Serial.println(word, HEX);
```

### Any outstanding TODOs or known issues