### PR TITLE
Add better error handling for i2c

### DIFF
--- a/src/BME280.cpp
+++ b/src/BME280.cpp
@@ -398,7 +398,7 @@ float BME280::hum()
 
 
 /****************************************************************/
-void BME280::read
+bool BME280::read
 (
    float& pressure,
    float& temp,
@@ -411,7 +411,7 @@ void BME280::read
    int32_t t_fine;
    if(!ReadData(data)){
       pressure = temp = humidity = NAN;
-      return;
+      return false;
    }
    uint32_t rawPressure = (data[0] << 12) | (data[1] << 4) | (data[2] >> 4);
    uint32_t rawTemp = (data[3] << 12) | (data[4] << 4) | (data[5] >> 4);
@@ -419,6 +419,7 @@ void BME280::read
    temp = CalculateTemperature(rawTemp, t_fine, tempUnit);
    pressure = CalculatePressure(rawPressure, t_fine, presUnit);
    humidity = CalculateHumidity(rawHumidity, t_fine);
+   return true;
 }
 
 

--- a/src/BME280.h
+++ b/src/BME280.h
@@ -183,7 +183,7 @@ public:
 
    /////////////////////////////////////////////////////////////////
    /// Read the data from the BME280 in the specified unit.
-   void   read(
+   bool read(
       float&    pressure,
       float&    temperature,
       float&    humidity,

--- a/src/BME280I2C.cpp
+++ b/src/BME280I2C.cpp
@@ -28,16 +28,16 @@ of www.endmemo.com, altitude equation courtesy of NOAA, and dew point equation
 courtesy of Brian McNoldy at http://andrew.rsmas.miami.edu.
  */
 
-#include <Wire.h>
-
 #include "BME280I2C.h"
 
 
 /****************************************************************/
 BME280I2C::BME280I2C
 (
+  TwoWire& wire,
   const Settings& settings
 ):BME280(settings),
+  m_wire(wire),
   m_settings(settings)
 {
 }
@@ -68,12 +68,10 @@ bool BME280I2C::WriteRegister
   uint8_t data
 )
 {
-  Wire.beginTransmission(m_settings.bme280Addr);
-  Wire.write(addr);
-  Wire.write(data);
-  Wire.endTransmission();
-
-  return true; // TODO: Check return values from wire calls.
+  m_wire.beginTransmission(m_settings.bme280Addr);
+  m_wire.write(addr);
+  m_wire.write(data);
+  return m_wire.endTransmission() == 0;
 }
 
 
@@ -85,18 +83,24 @@ bool BME280I2C::ReadRegister
   uint8_t length
 )
 {
-  uint8_t ord(0);
 
-  Wire.beginTransmission(m_settings.bme280Addr);
-  Wire.write(addr);
-  Wire.endTransmission();
-
-  Wire.requestFrom(static_cast<uint8_t>(m_settings.bme280Addr), length);
-
-  while(Wire.available())
+  m_wire.beginTransmission(m_settings.bme280Addr);
+  m_wire.write(addr);
+  if (m_wire.endTransmission() != 0)
   {
-    data[ord++] = Wire.read();
+	  return false;
   }
 
-  return ord == length;
+  if (m_wire.requestFrom(static_cast<uint8_t>(m_settings.bme280Addr), length) != length)
+  {
+	  return false;
+  }
+
+  uint8_t bytesRead = 0;
+  while(bytesRead < length && m_wire.available())
+  {
+    data[bytesRead++] = m_wire.read();
+  }
+
+  return bytesRead == length;
 }

--- a/src/BME280I2C.h
+++ b/src/BME280I2C.h
@@ -31,6 +31,7 @@ Based on the data sheet provided by Bosch for the Bme280 environmental sensor.
 #define TG_BME_280_I2C_H
 
 #include "BME280.h"
+#include <Wire.h>
 
 //////////////////////////////////////////////////////////////////
 /// BME280I2C - I2C Implementation of BME280.
@@ -66,7 +67,7 @@ public:
    ///////////////////////////////////////////////////////////////
    /// Constructor used to create the class. All parameters have
    /// default values.
-   BME280I2C(
+   BME280I2C(TwoWire& wire,
       const Settings& settings = Settings());
 
 
@@ -85,7 +86,7 @@ public:
 protected:
 
 private:
-
+   TwoWire& m_wire;
    Settings m_settings;
 
    //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
 - Added checking if Wire.endTransmission is returning 0 to check if i2c operation was successfully
 - Changed read method from void to bool, it will return false if read was unsuccessfull
 - Allow user to specify which Wire instance to use