### PR TITLE
Include Arduino.h to fix compiler warnings

### DIFF
--- a/src/BME280.cpp
+++ b/src/BME280.cpp
@@ -28,6 +28,7 @@ of www.endmemo.com, altitude equation courtesy of NOAA, and dew point equation
 courtesy of Brian McNoldy at http://andrew.rsmas.miami.edu.
  */
 
+#include <Arduino.h>
 #include <Wire.h>
 
 #include "BME280.h"

--- a/src/BME280I2C.cpp
+++ b/src/BME280I2C.cpp
@@ -28,6 +28,7 @@ of www.endmemo.com, altitude equation courtesy of NOAA, and dew point equation
 courtesy of Brian McNoldy at http://andrew.rsmas.miami.edu.
  */
 
+#include <Arduino.h>
 #include <Wire.h>
 
 #include "BME280I2C.h"


### PR DESCRIPTION
### Related issue # and issue behavior
Compiler generates warnings
```
.arduino15/packages/arduino/tools/CMSIS-Atmel/1.2.0/CMSIS/Device/ATMEL/samd21/include/samd21g18a.h:226:0: warning: "LITTLE_ENDIAN" redefined
 #define LITTLE_ENDIAN          1

.arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4/arm-none-eabi/include/machine/endian.h:17:0: note: this is the location of the previous definition
 #define LITTLE_ENDIAN _LITTLE_ENDIAN
```
from files
```
BME280/src/BME280.cpp:31
BME280/src/BME280I2C.cpp:31
```
When building for Arduino Nano 33 IoT
### Description of changes/fixes
Including Arduino.h stops these warnings being generated.

### @mention a person to review

### Steps to test
Build with and without these changes in an environment that doesn't supress warnings.

### Any outstanding TODOs or known issues